### PR TITLE
Port to Minecraft 26.1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: setup jdk
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'microsoft'
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version "${loom_version}"
+    id 'net.fabricmc.fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 }
 
@@ -8,13 +8,6 @@ group = project.maven_group
 
 base {
 	archivesName = project.archives_base_name
-}
-
-repositories {
-	maven {
-		name = 'ParchmentMC'
-		url = 'https://maven.parchmentmc.org'
-	}
 }
 
 loom {
@@ -32,14 +25,10 @@ loom {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings loom.layered() {
-		officialMojangMappings()
-		parchment("org.parchmentmc.data:parchment-1.21.10:2025.10.12@zip")
-	}
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.5.0")))
 }
@@ -53,7 +42,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {
@@ -62,8 +51,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.toVersion(25)
+	targetCompatibility = JavaVersion.toVersion(25)
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.10
-loader_version=0.18.2
-loom_version=1.14-SNAPSHOT
+minecraft_version=26.1.2
+loader_version=0.18.4
+loom_version=1.15-SNAPSHOT
 
 # Mod Properties
 mod_version=1.0.1
@@ -14,4 +14,4 @@ maven_group=me.incend1um.noinputlagtickrate
 archives_base_name=noinputlagtickrate
 
 # Dependencies
-fabric_version=0.138.3+1.21.10
+fabric_version=0.149.0+26.1.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/me/incend1um/noinputlagtickrate/NoInputLagTickRateClient.java
+++ b/src/client/java/me/incend1um/noinputlagtickrate/NoInputLagTickRateClient.java
@@ -2,17 +2,17 @@ package me.incend1um.noinputlagtickrate;
 
 import me.incend1um.noinputlagtickrate.mixin.client.access.MinecraftAccess;
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents;
-import net.minecraft.Util;
+import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
+import net.minecraft.util.Util;
 
 public class NoInputLagTickRateClient implements ClientModInitializer {
 	public static DeltaTracker.Timer inputDeltaTracker = new DeltaTracker.Timer(20.0f, 0, NoInputLagTickRateClient::tickTargetMspt);
 
 	@Override
 	public void onInitializeClient() {
-		WorldRenderEvents.START_MAIN.register((worldRenderContext) -> {
+		LevelRenderEvents.START_MAIN.register((worldRenderContext) -> {
 			Minecraft mc = Minecraft.getInstance();
 
 			if (mc.screen != null) {
@@ -20,7 +20,7 @@ public class NoInputLagTickRateClient implements ClientModInitializer {
 			}
 
 			if (mc.getOverlay() == null && mc.screen == null) {
-				int ticksDue = Math.min(10, inputDeltaTracker.advanceTime(Util.getMillis(), true));
+				int ticksDue = Math.min(10, inputDeltaTracker.advanceGameTime(Util.getMillis()));
 				for (int i = 0; i < ticksDue; i++) {
 					MinecraftAccess access = (MinecraftAccess) mc;
 

--- a/src/client/resources/noinputlagtickrate.client.mixins.json
+++ b/src/client/resources/noinputlagtickrate.client.mixins.json
@@ -1,7 +1,7 @@
 {
 	"required": true,
 	"package": "me.incend1um.noinputlagtickrate.mixin.client",
-	"compatibilityLevel": "JAVA_21",
+	"compatibilityLevel": "JAVA_25",
 	"client": [
 		"MinecraftMixin",
 		"MultiPlayerGameModeMixin",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.18.4",
-		"minecraft": ">=26.1 <=26.1.2",
+		"minecraft": "~26.1",
 		"java": ">=25",
 		"fabric-api": "*"
 	}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,9 +27,9 @@
 		}
 	],
 	"depends": {
-		"fabricloader": ">=0.18.2",
-		"minecraft": ">=1.21.10",
-		"java": ">=21",
+		"fabricloader": ">=0.18.4",
+		"minecraft": ">=26.1 <=26.1.2",
+		"java": ">=25",
 		"fabric-api": "*"
 	}
 }

--- a/src/main/resources/noinputlagtickrate.mixins.json
+++ b/src/main/resources/noinputlagtickrate.mixins.json
@@ -1,7 +1,7 @@
 {
 	"required": true,
 	"package": "me.incend1um.noinputlagtickrate.mixin",
-	"compatibilityLevel": "JAVA_21",
+	"compatibilityLevel": "JAVA_25",
 	"mixins": [
 	],
 	"injectors": {


### PR DESCRIPTION
Changes:
- Updated Minecraft compatibility to 26.1.x
- Updated Fabric Loader, Fabric API, Fabric Loom versions
- Migrated rendering event usage for newer Fabric APIs
- Updated timing API calls required for newer Minecraft versions
- Updated Java target (21 to 25)
- Updated Gradle wrapper and build configuration